### PR TITLE
Set OPENMP to -fopenmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAX_KMER_SIZE=64
 CXXFLAGS = -c -Wall -Wno-reorder $(INCLUDES) -DMAX_KMER_SIZE=$(MAX_KMER_SIZE) -fopenmp
 LDFLAGS =
 #OPENMP=-lgomp
-OPENMP=
+OPENMP=-fopenmp
 LDLIBS  = -lm -lz $(OPENMP)
 
 all: CXXFLAGS += -O3


### PR DESCRIPTION
Fix the error:

```
g++ -I.  lsb.o Kmer.o KmerIterator.o hash.o RepHash.o KmerStream.o  -lm -lz  -o KmerStream
Undefined symbols for architecture x86_64:
  "_GOMP_barrier", referenced from:
      void RunThreadedFastqStream<ReadQualityHasher>(ProgramOptions const&) [clone ._omp_fn.0] in KmerStream.o
```
